### PR TITLE
Podcast Player restyle

### DIFF
--- a/controllers/videos.js
+++ b/controllers/videos.js
@@ -24,8 +24,6 @@ module.exports = {
             videoObjs.push(object)
            }
             
-    
-      
             res.render('videos.ejs', { videos: videoObjs})
         } catch(err) {
             if(err) {

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -15,8 +15,13 @@
   
   body {
     font-family: 'Creepster', serif;
+    margin: 0;
+    width: 100%;
+    height: 100%;
   }
-  
+
+
+
   /* Pages */
   
   
@@ -82,26 +87,52 @@
   
   /* Video */
   
+  
   .Video {
     margin: 0 2%;
   }
   
   .player-container {
-    width: 95%;
-    margin: 5% 0;
+    width: 80%;
+    margin: 8% 10%;
     display: flex;
-  }
+}
 
-  .video-list{
-    outline: 3px solid red;
-    width: 20%;
-    height: 535px;
-   
-  }
+.player-container iframe{
+  width: 78%;
+  height: 92%;
+}
+
+.player-container h5{
+  font-size: x-large;
+  width: 79%;
+}
+
+.video-list {
+  width: 90%;
+  height: 535px;
+}
+
   .main-show {
     margin: 0 auto;
 
   }
+
+  .video span {
+    font-size: x-large;
+    background-color: #69215d;
+    margin-left: 3%;
+}
+
+  
+  li.video {
+    margin: 0% -5%;
+    margin-top: 0;
+    background-color: #69215d;
+    height: 24%;
+    width: 100%;
+    /* border: lightyellow; */
+}
   
   /* Nav menu */
   
@@ -242,13 +273,16 @@
   
   .episode span {
     font-size: 1.5rem;
+    background-color: inherit;
+}
+  .episode span:hover {
+    color: #11061e;
   }
-  
   
   .episode:hover {
     cursor: grab;
     background-color: antiquewhite;
-    color: coral;
+    color: #11061e;
   }
 
 
@@ -262,34 +296,38 @@
     display: flex;
     width: 98%;
     margin: 5% auto;
-  }
+    flex-direction: column;
+}
 
   .about-body-container p {
-    margin: 2%;
-    width: 50%;
+    margin: 0 0 0 14%;
+    width: 37%;
     font-size: x-large;
-  }
+}
 
-  .about-portrait {
-    height: 500px;
-    width: 46%;
-    padding: 2%;
-    padding-top: 0;
-  }
+.about-portrait {
+  height: 565px;
+  width: 34%;
+  padding: 2%;
+  padding-top: 0;
+  margin: 0 -9%;
+}
 
-  .portrait-and-para{
-    display: flex;
-    width: 69%;
-    flex-wrap: wrap;
-  }
+.portrait-and-para {
+  display: flex;
+  width: 100%;
+  /* flex-wrap: wrap; */
+  margin: 0 15%;
+}
 
   .contact-form-container {
-    width: 30%;
+    width: 56%;
     height: 19%;
     background-color: #69215d;
     text-align: center;
     padding: 2%;
-  }
+    margin: 5% auto;
+}
   
   .contact-form-container h3 {
     background-color: #69215d;
@@ -356,3 +394,11 @@
     width: 100%;
   }
   
+
+  /* Footer */
+
+  #footer {
+      width: 100%;
+      margin-top: 14%;
+      height: 150px;
+  }

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -265,19 +265,18 @@
   .episode{
     border-bottom: 2px solid #69215d;
     width: 100%;
-    padding: 1% 2%;
     display:flex;
-    margin: 2% 0;
-    justify-content: space-between;
   }
   
   .episode span {
     font-size: 1.5rem;
     background-color: inherit;
+    height: 50px;
+    padding: 2%;
 }
-  .episode span:hover {
+  /* .episode span:hover {
     color: #11061e;
-  }
+  } */
   
   .episode:hover {
     cursor: grab;
@@ -285,7 +284,14 @@
     color: #11061e;
   }
 
+  #episode-length {
+    width: 30%;
+    text-align: end;
+  }
 
+  #episode-title {
+    width: 70%;
+  }
 
   #episode-source {
     display: none;

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -43,7 +43,6 @@ function loadTrack(src) {
 
 function selectEpisode(event){
 	let target = event.target; //target child element
-	console.log(target)
 	select(target); // select episode to play
 }
 
@@ -54,8 +53,9 @@ function select(ep) {
 
 	document.getElementById('episode-name').style.opacity = 0;
 
-	let src = ep.parentNode.childNodes[5].innerHTML;
-	console.log(src)
+	
+	// update this to target episode source <span>
+	let src = ep.parentNode.childNodes[5].innerText;
 	loadTrack(src)
 	playTrack()
 

--- a/views/about.ejs
+++ b/views/about.ejs
@@ -42,7 +42,7 @@
                     <a href="/#episodes">Episodes</a>
                   </li>
                   <li>
-                    <a href="">Merch</a>
+                    <a href="https://www.imdb.com/name/nm2074421/">IMDB</a>
                   </li>
                   <li>
                     <a href="https://www.patreon.com/HiStrangeness/membership">Patreon</a>

--- a/views/about.ejs
+++ b/views/about.ejs
@@ -45,7 +45,7 @@
                     <a href="">Merch</a>
                   </li>
                   <li>
-                    <a href="">Patreon</a>
+                    <a href="https://www.patreon.com/HiStrangeness/membership">Patreon</a>
                   </li>
                 </ul>
             </section>
@@ -68,28 +68,7 @@
         <div class="about-body-container">
           <div class="portrait-and-para">
           <img class="about-portrait" src="/assets/images/newLogo.png"/>
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed et erat purus. 
-            Sed lacinia, nibh eget efficitur tincidunt, mi nulla condimentum elit, 
-            lacinia maximus massa massa finibus nisi. Nam sit amet eros leo. Morbi 
-            pretium quis nisl a auctor. Nam convallis semper risus vitae sollicitudin.
-             Nam tempor luctus sollicitudin. In accumsan egestas consectetur. Sed mattis 
-             neque malesuada magna maximus, in mollis diam mollis. Morbi efficitur congue 
-             neque, ut molestie purus pharetra vel. Sed eu elit et elit ultricies vehicula 
-             a eu tortor. Mauris quam diam, congue sit amet suscipit eget, gravida sit amet 
-             augue. Maecenas accumsan, lorem vel elementum viverra, ex arcu faucibus neque, 
-             sit amet posuere diam augue quis nibh. Nam ut urna sed ligula cursus faucibus ac 
-             convallis nibh. Proin eget nibh nec odio consequat fringilla. Ut mattis tortor ut 
-             nulla porta ultricies.
-            Vestibulum ac tellus mattis, elementum leo id, dignissim nulla. Cras rutrum semper
-             hendrerit. Fusce in fermentum ligula, sed ultricies tellus. Phasellus aliquet dignissim
-              mi. Duis mattis, mauris vel fringilla elementum, lacus ipsum imperdiet massa, ac 
-              commodo ligula leo et arcu. Cras pulvinar, odio non blandit suscipit, ante ligula
-              condimentum lorem, vel mollis ligula dui tincidunt est. Aliquam erat volutpat. 
-              Aenean imperdiet nunc ipsum, a maximus quam pretium a. Aliquam ac iaculis nunc, 
-              vitae pretium metus. In euismod sed est eget lacinia. Vivamus semper eget nulla 
-              id facilisis. Quisque vel sodales nisl, sit amet posuere massa. Morbi posuere 
-              venenatis nunc in consequat. Aliquam massa turpis, sodales at rhoncus hendrerit, 
-              volutpat at orci.
+          <p>Steve Berg is an actor and improviser who just finished work on Tim Kasher’s film Who’s Watching. He can also be seen in Olivia Wilde’s new film Don’t Worry Darling, and is currently working on the feature film Snack Shack. He’s also been obsessed with UFOs, the paranormal, the occult and all things weird his entire life. Whenever he has the opportunity he lectures about Weird Nebraska at conferences and events. He can also be seen in New Line’s comedy feature Tag starring Jon Hamm and Rashida Jones. His credits also include recurring roles on NBC's The Good Place, ABC's The Goldbergs, Comedy Central's Idiotsitter, and BET's The Comedy Get Down. He has appeared in two features for director Joe Swanberg -- the Netflix Original Win It All and the indie Digging For Fire which premiered at the 2015 Sundance Film Festival. Other credits include Mike White's directorial debut Year of the Dog, Jared Hess’ Gentlemen Broncos, and Joss Whedon's digital series Dr. Horrible's Sing Along-Along Blog. Berg has been a drunk narrator multiple times on Comedy Central's Drunk History and was a series regular in the Fox Television pilot WTF America produced by Ron Howard and Brian Grazer. He is originally from Omaha, Nebraska.
           </p>
         </div>
           <div class='contact-form-container'>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -45,7 +45,7 @@
                     <a href="">Merch</a>
                   </li>
                   <li>
-                    <a href="">Patreon</a>
+                    <a href="https://www.patreon.com/HiStrangeness/membership">Patreon</a>
                   </li>
                 </ul>
             </section>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -42,7 +42,7 @@
                     <a href="/#episodes">Episodes</a>
                   </li>
                   <li>
-                    <a href="">Merch</a>
+                    <a href="https://www.imdb.com/name/nm2074421/">IMDB</a>
                   </li>
                   <li>
                     <a href="https://www.patreon.com/HiStrangeness/membership">Patreon</a>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -131,7 +131,7 @@
                 <% episodes.forEach( el => { %>
                     <li class="episode" >
                         <span class="<%= el.title %>" id="episode-title"><%= el.title %></span>
-                        <span class="episode-length"><%= el.duration %></span>
+                        <span class="episode-length" id="episode-length"><%= el.duration %></span>
                         <span class="source" id="episode-source" ><%= el.audio_url %></span>
                     </li>
                 <% }) %>  

--- a/views/videos.ejs
+++ b/views/videos.ejs
@@ -45,7 +45,7 @@
                     <a href="">Merch</a>
                   </li>
                   <li>
-                    <a href="">Patreon</a>
+                    <a href="https://www.patreon.com/HiStrangeness/membership">Patreon</a>
                   </li>
                 </ul>
             </section>

--- a/views/videos.ejs
+++ b/views/videos.ejs
@@ -42,7 +42,7 @@
                     <a href="/#episodes">Episodes</a>
                   </li>
                   <li>
-                    <a href="">Merch</a>
+                    <a href="https://www.imdb.com/name/nm2074421/">IMDB</a>
                   </li>
                   <li>
                     <a href="https://www.patreon.com/HiStrangeness/membership">Patreon</a>
@@ -53,7 +53,8 @@
         
         <section class="player-container">
           <section>
-            <iframe class="main-show" width="960" height="540" src="//www.youtube.com/embed/_yopTNk6dUQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <%- videos[0].player.embedHtml %>
+
             <h3><%= videos[0].snippet.title %></h3>
             <h5><%= videos[0].snippet.description %></h5>
           </section>
@@ -69,7 +70,7 @@
        
 
     <!-- Footer  -->
-    <div>
+    <div id="footer">
       <hr/>
       <h3>Footer</h3>
   </div>


### PR DESCRIPTION
Fixed the episode player so that when user clicks anywhere on episode item, it loads that episode. Previously it would only load when the title of the ep is clicked due to a flexbox - justify context oversight with click events 

also restyled episode items for a cleaner design