### PR TITLE
fixed styles for hover over episode items

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -278,7 +278,7 @@
     color: #11061e;
   } */
   
-  .episode:hover {
+  .episode:hover span {
     cursor: grab;
     background-color: antiquewhite;
     color: #11061e;


### PR DESCRIPTION
now when a cursor hovers over the episode items on the podcast player, both the title and the duration are recolored